### PR TITLE
actions: add Auto-assign Issue action

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,15 @@
+name: Assign reviewer to PR
+on:
+    pull_request:
+        types: [opened]
+jobs:
+    auto-assign:
+        runs-on: ubuntu-latest
+        steps:
+            - name: 'Auto-assign PR'
+              uses: pozil/auto-assign-issue@v1
+              with:
+                  abortIfPreviousAssignees: true
+                  repo-token: ${{ secrets.MY_PERSONAL_ACCESS_TOKEN }}
+                  teams: code-reviewers
+                  numOfAssignee: 1


### PR DESCRIPTION
This pull request adds the [Auto-assign Issue GitHub Action](https://github.com/marketplace/actions/auto-assign-issue), which will automatically assign a member of @tcmg-412-group-1/code-reviewers to each pull request. This should help evenly distribute the workload of code reviews.